### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Timer/keywords.txt
+++ b/Timer/keywords.txt
@@ -8,9 +8,9 @@ Timer	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-reset   KEYWORD2
-every   KEYWORD2
-pause   KEYWORD2
-resume  KEYWORD2
-updatePeriod KEYWORD2
-process KEYWORD2
+reset	KEYWORD2
+every	KEYWORD2
+pause	KEYWORD2
+resume	KEYWORD2
+updatePeriod	KEYWORD2
+process	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords